### PR TITLE
Handle dateTime and date as expected

### DIFF
--- a/.changeset/twelve-seals-bathe.md
+++ b/.changeset/twelve-seals-bathe.md
@@ -1,0 +1,7 @@
+---
+"clear-sparql-cache-endpoint": patch
+---
+
+All results were returned as strings, which was breaking the logic.
+
+Now, everything is converted as dateTime, and it assumes that a date having hours, minutes and seconds set to zero is a value converted from a date.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clear-sparql-cache-endpoint",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clear-sparql-cache-endpoint",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.651.1",


### PR DESCRIPTION
All results were returned as strings, which was breaking the logic.

Now, everything is converted as dateTime, and it assumes that a date having hours, minutes and seconds set to zero is a value converted from a date.

cc @Rdataflow