### PR TITLE
Create ESLint dependency group for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "@stylistic/eslint-plugin-js"


### PR DESCRIPTION
This makes sure that ESLint related packages are updated in a same PR.